### PR TITLE
fix: 如果执行安装前存在/etc/v2ray目录会导致git clone 出错

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -752,11 +752,13 @@ install_v2ray() {
 		mkdir -p /etc/v2ray/233boy/v2ray
 		cp -rf $(pwd)/* /etc/v2ray/233boy/v2ray
 	else
+		pushd /tmp
 		if [[ $_test ]]; then
 			git clone https://github.com/233boy/v2ray -b test /etc/v2ray/233boy/v2ray
 		else
 			git clone https://github.com/233boy/v2ray /etc/v2ray/233boy/v2ray
 		fi
+		popd
 
 	fi
 


### PR DESCRIPTION
重现方法
```
mkdir -p /etc/v2ray/
cd /etc/v2ray/
bash <(curl -s -L https://233now.com/v2ray.sh)
```
原因：740行的`[ -d /etc/v2ray ] && rm -rf /etc/v2ray`，如果恰好用户在当前这个目录，被删除后git就找不到了..
解决：git clone时候先跳去别的目录，pushd/popd命令就比较合适了。