### PR TITLE
update caddy donwload link to linux_amd64

### DIFF
--- a/src/download-caddy.sh
+++ b/src/download-caddy.sh
@@ -2,7 +2,7 @@ _download_caddy_file() {
 	caddy_tmp="/tmp/install_caddy/"
 	caddy_tmp_file="/tmp/install_caddy/caddy.tar.gz"
 	[[ -d $caddy_tmp ]] && rm -rf $caddy_tmp
-	local caddy_download_link="https://caddyserver.com/download/linux/${caddy_arch}?license=personal"
+	local caddy_download_link="https://github.com/caddyserver/caddy/releases/download/v1.0.3/caddy_v1.0.3_linux_amd64.tar.gz"
 
 	mkdir -p $caddy_tmp
 

--- a/v2ray.sh
+++ b/v2ray.sh
@@ -7,8 +7,6 @@ magenta='\e[95m'
 cyan='\e[96m'
 none='\e[0m'
 
-# Root
-[[ $(id -u) != 0 ]] && echo -e " 哎呀……请使用 ${red}root ${none}用户运行 ${yellow}~(^_^) ${none}" && exit 1
 
 _version="v3.13"
 

--- a/v2ray.sh
+++ b/v2ray.sh
@@ -7,6 +7,8 @@ magenta='\e[95m'
 cyan='\e[96m'
 none='\e[0m'
 
+# Root
+[[ $(id -u) != 0 ]] && echo -e " 哎呀……请使用 ${red}root ${none}用户运行 ${yellow}~(^_^) ${none}" && exit 1
 
 _version="v3.13"
 


### PR DESCRIPTION
fix: caddy 下载连接改至 https://github.com/caddyserver/caddy/releases/download/v1.0.3/caddy_v1.0.3_linux_amd64.tar.gz
原版的下载连接已经不可用