### PR TITLE
fix: dnsserver失效

### DIFF
--- a/config/server/dynamic/http.json
+++ b/config/server/dynamic/http.json
@@ -117,7 +117,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/dynamic/kcp.json
+++ b/config/server/dynamic/kcp.json
@@ -89,7 +89,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/dynamic/quic.json
+++ b/config/server/dynamic/quic.json
@@ -91,7 +91,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/dynamic/tcp.json
+++ b/config/server/dynamic/tcp.json
@@ -76,7 +76,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/dynamic/ws.json
+++ b/config/server/dynamic/ws.json
@@ -79,7 +79,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/h2.json
+++ b/config/server/h2.json
@@ -72,7 +72,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/http.json
+++ b/config/server/http.json
@@ -90,7 +90,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/kcp.json
+++ b/config/server/kcp.json
@@ -62,7 +62,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/quic.json
+++ b/config/server/quic.json
@@ -63,7 +63,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/tcp.json
+++ b/config/server/tcp.json
@@ -57,7 +57,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",

--- a/config/server/ws.json
+++ b/config/server/ws.json
@@ -57,7 +57,7 @@
 	],
 	"dns": {
 		"servers": [
-			"https+local://1.1.1.1/dns-query",
+			"https+local://cloudflare-dns.com/dns-query",
 			"1.1.1.1",
 			"1.0.0.1",
 			"8.8.8.8",


### PR DESCRIPTION
目前使用https://1.1.1.1/dns-query会失效
![image](https://user-images.githubusercontent.com/16175551/77035186-f8747e00-69e6-11ea-81ed-f6b9818ec859.png)
看了下现在使用https://cloudflare-dns.com/dns-query可以正常使用
![image](https://user-images.githubusercontent.com/16175551/77035245-10e49880-69e7-11ea-8c6b-2185aeda5809.png)
