### PR TITLE
fix for new release structure of v2ray

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,20 +24,20 @@ i[36]86)
 	v2ray_bit="32"
 	caddy_arch="386"
 	;;
-x86_64)
+'amd64' | x86_64)
 	v2ray_bit="64"
 	caddy_arch="amd64"
 	;;
 *armv6*)
-	v2ray_bit="arm"
+	v2ray_bit="arm32-v6"
 	caddy_arch="arm6"
 	;;
 *armv7*)
-	v2ray_bit="arm"
+	v2ray_bit="arm32-v7a"
 	caddy_arch="arm7"
 	;;
 *aarch64* | *armv8*)
-	v2ray_bit="arm64"
+	v2ray_bit="arm64-v8a"
 	caddy_arch="arm64"
 	;;
 *)


### PR DESCRIPTION
v2ray 4.27.0 changed the release structure.

Please see [fhs-install-v2ray](https://github.com/v2fly/fhs-install-v2ray/blob/82f1734386e61c3c4042ee2f402009ae42eb4f3d/install-release.sh#L29) and [v2ray release note](https://github.com/v2fly/v2ray-core/releases/tag/v4.27.0) for more infomation