### PR TITLE
解决使用该脚本在国内环境部署时的多种报错

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Usage: v2ray [options]... [args]...
    xapi [...]                                      同等于 v2ray api, 但 API 后端使用当前运行的 V2Ray 服务
 
 其他:
+   proxy [url]                                     设置代理
    bbr                                             启用 BBR, 如果支持
    bin [...]                                       运行 V2Ray 命令, 例如: v2ray bin help
    api, convert, tls, run, uuid  [...]             兼容 V2Ray 命令

--- a/install.sh
+++ b/install.sh
@@ -196,9 +196,9 @@ download() {
 # get server ip
 get_ip() {
 	disable_proxy
-    export "$(wget -4 -qO- https://one.one.one.one/cdn-cgi/trace | grep ip=)" &>/dev/null
+    export "$(wget -4 -qO- https://cloudflare.com/cdn-cgi/trace | grep ip=)" &>/dev/null
 	enable_proxy
-    [[ -z $ip ]] && export "$(wget -6 -qO- https://one.one.one.one/cdn-cgi/trace | grep ip=)" &>/dev/null
+    [[ -z $ip ]] && export "$(wget -6 -qO- https://cloudflare.com/cdn-cgi/trace | grep ip=)" &>/dev/null
 }
 
 # check background tasks status

--- a/src/core.sh
+++ b/src/core.sh
@@ -125,8 +125,8 @@ get_uuid() {
 
 get_ip() {
     [[ $ip || $is_no_auto_tls || $is_gen || $is_dont_get_ip ]] && return
-    export "$(_wget -4 -qO- https://one.one.one.one/cdn-cgi/trace | grep ip=)" &>/dev/null
-    [[ ! $ip ]] && export "$(_wget -6 -qO- https://one.one.one.one/cdn-cgi/trace | grep ip=)" &>/dev/null
+    export "$(_wget -4 -qO- https://cloudflare.com/cdn-cgi/trace | grep ip=)" &>/dev/null
+    [[ ! $ip ]] && export "$(_wget -6 -qO- https://cloudflare.com/cdn-cgi/trace | grep ip=)" &>/dev/null
     [[ ! $ip ]] && {
         err "获取服务器 IP 失败.."
     }
@@ -1420,7 +1420,7 @@ get() {
         # is_host_dns=$(ping $host $is_ip_type -c 1 -W 2 | head -1)
         is_dns_type="a"
         [[ $(grep ":" <<<$ip) ]] && is_dns_type="aaaa"
-        is_host_dns=$(_wget -qO- --header="accept: application/dns-json" "https://one.one.one.one/dns-query?name=$host&type=$is_dns_type")
+        is_host_dns=$(_wget -qO- --header="accept: application/dns-json" "https://cloudflare-dns.com/dns-query?name=$host&type=$is_dns_type")
         ;;
     log | logerr)
         msg "\n 提醒: 按 $(_green Ctrl + C) 退出\n"

--- a/src/core.sh
+++ b/src/core.sh
@@ -125,9 +125,11 @@ get_uuid() {
 
 get_ip() {
     [[ $ip || $is_no_auto_tls || $is_gen || $is_dont_get_ip ]] && return
-    export "$(_wget -4 -qO- https://cloudflare.com/cdn-cgi/trace | grep ip=)" &>/dev/null
-    [[ ! $ip ]] && export "$(_wget -6 -qO- https://cloudflare.com/cdn-cgi/trace | grep ip=)" &>/dev/null
-    [[ ! $ip ]] && {
+	disable_proxy
+    export "$(wget -4 -qO- https://cloudflare.com/cdn-cgi/trace | grep ip=)" &>/dev/null
+    [[ ! $ip ]] && export "$(wget -6 -qO- https://cloudflare.com/cdn-cgi/trace | grep ip=)" &>/dev/null
+    enable_proxy
+	[[ ! $ip ]] && {
         err "获取服务器 IP 失败.."
     }
 }
@@ -1420,7 +1422,7 @@ get() {
         # is_host_dns=$(ping $host $is_ip_type -c 1 -W 2 | head -1)
         is_dns_type="a"
         [[ $(grep ":" <<<$ip) ]] && is_dns_type="aaaa"
-        is_host_dns=$(_wget -qO- --header="accept: application/dns-json" "https://cloudflare-dns.com/dns-query?name=$host&type=$is_dns_type")
+        is_host_dns=$(wget -qO- --header="accept: application/dns-json" "https://cloudflare-dns.com/dns-query?name=$host&type=$is_dns_type")
         ;;
     log | logerr)
         msg "\n 提醒: 按 $(_green Ctrl + C) 退出\n"
@@ -1597,6 +1599,24 @@ footer_msg() {
     ####### 要点13脸吗只会改我链接的小人 #######
 }
 
+# update proxy
+proxy() {
+	if [[ -z $1 ]]; then
+		if [[ $(jq 'has("proxy")' $is_config_json) == 'false' ]]; then
+			echo "当前未配置代理"
+		else
+			echo "当前代理: $(jq -r '.proxy' $is_config_json)"
+		fi
+	else
+		url_pattern='(https?|socks5)://[-[:alnum:]\+&@#/%?=~_|!:,.;]+'
+		if ! [[ $1 =~ $url_pattern ]]; then
+			err "代理地址格式不正确"
+		fi
+		cat <<<$(jq ".proxy=\"$1\"" $is_config_json) >$is_config_json
+		echo "代理已更新为: $1"
+	fi
+}
+
 # URL or qrcode
 url_qr() {
     is_dont_show_info=1
@@ -1719,7 +1739,7 @@ is_main_menu() {
         show_help
         ;;
     9)
-        ask list is_do_other "启用BBR 查看日志 查看错误日志 测试运行 重装脚本 设置DNS"
+        ask list is_do_other "启用BBR 查看日志 查看错误日志 测试运行 重装脚本 设置DNS 设置代理"
         case $REPLY in
         1)
             load bbr.sh
@@ -1740,6 +1760,11 @@ is_main_menu() {
         6)
             load dns.sh
             dns_set
+            ;;
+		7)
+			proxy
+			ask string new_proxy "请输入代理地址:"
+			proxy $new_proxy
             ;;
         esac
         ;;
@@ -1904,6 +1929,9 @@ main() {
         ;;
     xapi)
         api ${@:2}
+        ;;
+    proxy)
+        proxy ${@:2}
         ;;
     h | help | --help)
         load help.sh

--- a/src/download.sh
+++ b/src/download.sh
@@ -13,7 +13,7 @@ get_latest_version() {
         url="https://api.github.com/repos/$is_caddy_repo/releases/latest?v=$RANDOM"
         ;;
     esac
-    latest_ver=$(_wget -qO- $url | grep tag_name | egrep -o 'v([0-9.]+)')
+    latest_ver=$(wget -qO- --no-check-certificate $url | grep tag_name | egrep -o 'v([0-9.]+)')
     [[ ! $latest_ver ]] && {
         err "获取 ${name} 最新版本失败."
     }
@@ -75,7 +75,7 @@ download() {
     unset latest_ver
 }
 download_file() {
-    if ! _wget -t 5 -c $link -O $tmpfile; then
+    if ! wget -t 5 -c --no-check-certificate $link -O $tmpfile; then
         rm -rf $tmpdir
         err "\n下载 ${name} 失败.\n"
     fi

--- a/src/help.sh
+++ b/src/help.sh
@@ -62,6 +62,7 @@ show_help() {
             "   no-auto-tls [...]                               同等于 add, 但禁止自动配置 TLS, 可用于 *TLS 相关协议"
             "   xapi [...]                                      同等于 $is_core api, 但 API 后端使用当前运行的 $is_core_name 服务\n"
             "其他:"
+			"   proxy [url]                                     设置代理"
             "   bbr                                             启用 BBR, 如果支持"
             "   bin [...]                                       运行 $is_core_name 命令, 例如: $is_core bin help"
             "   api, convert, tls, run, uuid  [...]             兼容 $is_core_name 命令"

--- a/src/init.sh
+++ b/src/init.sh
@@ -52,12 +52,6 @@ load() {
     . $is_sh_dir/src/$1
 }
 
-# wget add --no-check-certificate
-_wget() {
-    # [[ $proxy ]] && export https_proxy=$proxy
-    wget --no-check-certificate "$@"
-}
-
 # yum or apt-get
 cmd=$(type -P apt-get || type -P yum)
 
@@ -99,6 +93,23 @@ is_https_port=443
 
 # core ver
 is_core_ver=$($is_core_bin version | head -n1 | cut -d " " -f1-2)
+
+# proxy
+enable_proxy() {
+	if [[ $proxy ]]; then
+		export http_proxy=$proxy
+		export https_proxy=$proxy
+	fi
+}
+disable_proxy() {
+	export http_proxy=
+	export https_proxy=
+}
+if [[ $(jq 'has("proxy")' $is_config_json) == "true" ]]; then
+	proxy=$(jq -r '.proxy' $is_config_json)
+	enable_proxy
+fi
+
 
 if [[ $(grep -o ^[0-9] <<<${is_core_ver#* }) -lt 5 ]]; then
     # core version less than 5, e.g, v4.45.2


### PR DESCRIPTION
该脚本在国内环境部署时由于代理设置不完善，以及国内 ISP 对 Cloudflare DNS 和 GitHub 的屏蔽，会在安装和运行时出现异常。#1404，#1405 和 #1406 三个 issue 分别描述了具体的问题。该 PR 修复了这些问题。修复的问题和新加入的特性已在国内环境进行了充分测试，现在该脚本可以借助其他代理服务器顺利完成在国内环境的服务部署。